### PR TITLE
actions를 위한 코드 추가

### DIFF
--- a/script/update_original.py
+++ b/script/update_original.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import requests
+import urllib.request
+from bs4 import BeautifulSoup
+from github import Github, InputGitAuthor
+
+MASTER_BRANCH = "master"
+MASTER_REF = "refs/heads/master"
+ORIGINAL_MARKDOWN_PATH = "Original.md"
+ACCESS_TOKEN = os.environ['ACCESS_TOKEN']
+REPO_NAME = "Yosseulsin-JOB/Google-Python-Style-Guide-kor"
+COMMIT_ID_CLASSNAME = ".text-small.text-mono.link-gray"
+MARDOWN_URL = "https://github.com/google/styleguide/blob/gh-pages/pyguide.md"
+RAW_MARKDOWN_URL = "https://raw.githubusercontent.com/google/styleguide/gh-pages/pyguide.md"
+
+def create_ref_name(commit):
+    return 'refs/heads/original/' + commit['label']
+
+def create_branch_name(commit):
+    return 'original/' + commit['label']
+
+def create_commit_title(commit):
+    return 'merge ' + commit['label'] + ' 🛰'
+
+def create_pr_title(commit):
+    return '['+commit['label']+'] 변역 요청 💬'
+
+def create_pr_body():
+    return '''
+새로운 번역이 왔습니다. 번역해주세요! 💤
+'''
+
+# 항상 루트에서 python ./script/update_original.py 로 실행해야 루트에 있는 Original.md 파일로 대체됩니다.
+def download_from_google_style_guide_original():
+    urllib.request.urlretrieve(RAW_MARKDOWN_URL, ORIGINAL_MARKDOWN_PATH)
+    print("저장완료")
+
+# commit 이름과 링크를 가져옵니다.
+def get_commit_from_google_style_guide_original():
+    markdown = requests.get(MARDOWN_URL).text
+    soup = BeautifulSoup(markdown, 'html.parser')
+    commit = soup.select(COMMIT_ID_CLASSNAME)[0]
+    commit_label = commit.text
+    commit_url = 'https://github.com' + commit.attrs['href']
+
+    print(commit_label, commit_url)
+
+    return { "label":commit_label,'url': commit_url }
+
+def get_repo():
+    return Github(ACCESS_TOKEN).get_repo(REPO_NAME)
+
+def create_branch(repo, commit):
+    ref = create_ref_name(commit)
+    branch = repo.get_branch(branch=MASTER_BRANCH)
+
+    try:
+      repo.create_git_ref(ref=ref, sha=branch.commit.sha)
+    except:
+      return False
+    return True
+
+def create_commit(repo, commit):
+    branch = create_branch_name(commit)
+    title = create_commit_title(commit)
+    text = open(ORIGINAL_MARKDOWN_PATH, "r").read()
+    contents = repo.get_contents(ORIGINAL_MARKDOWN_PATH, ref=MASTER_REF)
+
+    repo.update_file(contents.path, title, text, contents.sha, branch=branch)
+
+def create_pull_request(repo, commit):
+    body = create_pr_body()
+    head = create_branch_name(commit)
+    title = create_pr_title(commit)
+
+    repo.create_pull(title=title, body=body, head=head, base=MASTER_BRANCH)
+
+
+if __name__ == "__main__":
+
+    # 스타일 가이드를 최신 버전을 가져옵니다.
+    download_from_google_style_guide_original()
+
+    # 최신 버전의 commit id와 주소를 가져옵니다.
+    commit = get_commit_from_google_style_guide_original()
+
+    # 스타일 가이드 한글판 레포를 가져옵니다.
+    repo = get_repo()
+
+    # 브랜치를 생성합니다.
+    branch = create_branch(repo, commit)
+
+    # 브랜치를 생성할 수 없는 상태라면 이미 생성된 것으로 더이상의 작업을 진행하지 않습니다.
+    if branch is False:
+        print('이미 생성된 작업 요청과 동일한 Commit 입니다. 🚨')
+        sys.exit(0)
+    
+    # 업데이트 된 파일을 commit합니다.
+    create_commit(repo, commit)
+
+    # Pull Request를 생성합니다.
+    create_pull_request(repo, commit)
+
+    print("요청 완료했습니다.")
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/script/update_original.py
+++ b/script/update_original.py
@@ -103,17 +103,3 @@ if __name__ == "__main__":
     create_pull_request(repo, commit)
 
     print("요청 완료했습니다.")
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/script/update_original_requirements.txt
+++ b/script/update_original_requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4==4.7.1
+requests==2.22.0
+PyGithub==1.51


### PR DESCRIPTION
- 원본 Github에서 Python Guide Markdown을 가져옵니다. 
- 브랜치가 살아있는 경우 추가적인 작업을 수행하지 않습니다.
- 이 PR이 머지되면 actions 파일을 추가할 예정입니다. Actions는 매주 금요일 18시에 동작하도록 스케쥴을 작성할 예정입니다.
  - 테스트 결과 예상했던 대로 동작하지 않는 부분이 있어서 정확하게 18시에 동작하지 않을 수 있습니다. 
  - 바로 실행하는 기능이 있다면 좋겠지만 action이 있어야 동작해서 이 부분에 대해서는 고려를 해보겠습니다.
     - 임의의로 실행하기 위해 issue를 생성했을 경우 동작하게 하는 등 추가적인 작업을 할 예정입니다.

```yaml
name: Python-Style-Guide-Get-Original

on:
  schedule:
    # 매주 금요일 18:00에 실행합니다. (UTC +09:00) 
    - cron:  '0 9 * * 5'
  issues:
    # 이슈에 새로운 항목이 생기거나 수정사항이 있으면 실행합니다.
    types: [opened, edited]

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - name: Set up Python
        uses: actions/setup-python@v2
        with:
          python-version: 3.6
      - name: Install Dependencies
        run: |
          python -m pip install --upgrade pip
          if [ -f ./script/update_original_requirements.txt ]; then pip install -r ./script/update_original_requirements.txt; fi
      - name: Crawler
        run: |
          python ./script/update_original.py
        env:
          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
```